### PR TITLE
Add timestamp argument to publisher tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 *.project
 *.settings
 *application.properties
+*log4j.properties
 *checkstyle_report*.txt
 /target/

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <maven.compiler.version>1.8</maven.compiler.version>
     <spring.boot.version>2.3.3.RELEASE</spring.boot.version>
     <spring.version>5.2.6.RELEASE</spring.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
     <cmo_metadb_common.artifactId>cmo-metadb-common</cmo_metadb_common.artifactId>
@@ -44,6 +45,16 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -88,6 +99,23 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.9</version>
       <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3</version>
+      <type>jar</type>
+    </dependency>
+    <!-- slf4j -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -12,3 +12,4 @@ lims.username=
 lims.password=
 lims.request_samples_endpoint=
 lims.sample_manifest_endpoint=
+lims.request_deliveries_endpoint=

--- a/src/main/resources/log4j.properties.EXAMPLE
+++ b/src/main/resources/log4j.properties.EXAMPLE
@@ -1,0 +1,15 @@
+# Change INFO to DEBUG, if you want to see debugging info on underlying libraries we use.
+log4j.rootLogger=INFO, a
+
+# Change INFO to DEBUG, if you want see debugging info on our packages only.
+log4j.category.org.mskcc=INFO
+
+## IMPORTANT - THRESHOLD SHOULD NOT BE DEBUG FOR PRODUCTION, CREDENTIALS CAN BE DISPLAYED!
+
+log4j.appender.a = org.apache.log4j.FileAppender
+
+log4j.appender.a.File = /path/to/logfile.log
+
+log4j.appender.a.layout = org.apache.log4j.PatternLayout
+log4j.appender.a.layout.ConversionPattern = %d{yyyy-MM-dd HH:mm:ss} [%t] %-5p %c - %m%n
+log4j.appender.a.append = true


### PR DESCRIPTION
Publisher tool now supports these arguments
- request ids, comma-separated list of ids to call LimsRest directly with
- start date as YYYY/MM/DD, start date to use for getting set of request deliveries from LimsRest
- end date as YYYY/MM/DD, end date to limit date range of request deliveries fetched from LimsRest

Regardless of option(s) passed, the publisher tool will publish data fetched from LimsRest
on topic 'igo.new-request' to MetaDB.

**NOTE: Currently planning some basic refactoring to organize the publisher code and make it easier to support different modes as well as threading.** 


Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>