### PR TITLE
Update messaging lib, messagingGateway bean config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
     <slf4j.version>1.7.30</slf4j.version>
     <jackson.version>2.11.2</jackson.version>
     <!-- metadb messaging -->
-    <cmo_metadb_messaging_java.group>com.github.mskcc</cmo_metadb_messaging_java.group>
-    <cmo_metadb_messaging_java.version>c9d741e60a3068ee3b85dda4b02d1ed45325cfe0</cmo_metadb_messaging_java.version>
+    <cmo_metadb_messaging_java.group>com.github.ao508</cmo_metadb_messaging_java.group>
+    <cmo_metadb_messaging_java.version>c757f5c120fdb8d46fe5970892a7d6a6c2f3d7a4</cmo_metadb_messaging_java.version>
     <!-- metadb common centralized config properties -->
     <cmo_metadb_common.groupId>com.github.mskcc</cmo_metadb_common.groupId>
     <cmo_metadb_common.artifactId>cmo-metadb-common</cmo_metadb_common.artifactId>

--- a/src/main/java/org/mskcc/cmo/publisher/CmoMetaDbPublisherPipeline.java
+++ b/src/main/java/org/mskcc/cmo/publisher/CmoMetaDbPublisherPipeline.java
@@ -62,7 +62,6 @@ public class CmoMetaDbPublisherPipeline {
         System.exit(SpringApplication.exit(ctx));
     }
 
-
     /**
      * Validate the start and end dates provided if applicable.
      * @param startDate

--- a/src/main/java/org/mskcc/cmo/publisher/pipeline/config/BatchConfiguration.java
+++ b/src/main/java/org/mskcc/cmo/publisher/pipeline/config/BatchConfiguration.java
@@ -68,9 +68,10 @@ public class BatchConfiguration {
     @Autowired
     private Gateway messagingGateway;
 
-    @Autowired
-    public void initMessagingGateway() throws Exception {
+    @Bean
+    public Gateway messagingGateway() throws Exception {
         messagingGateway.connect();
+        return messagingGateway;
     }
 
     /**


### PR DESCRIPTION
Update cmo-messaging-library commit hash for jitpack.

Updated how messaing gateway bean is configured in batch configuration
so that the shutdown method is automatically invoked upon job completion
by the spring batch disposable bean

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>