### PR TITLE
Support for fetching requests directly from Metadb web service

### DIFF
--- a/src/main/java/org/mskcc/cmo/publisher/pipeline/config/BatchConfiguration.java
+++ b/src/main/java/org/mskcc/cmo/publisher/pipeline/config/BatchConfiguration.java
@@ -12,6 +12,8 @@ import org.mskcc.cmo.publisher.pipeline.limsrest.LimsRequestListener;
 import org.mskcc.cmo.publisher.pipeline.limsrest.LimsRequestProcessor;
 import org.mskcc.cmo.publisher.pipeline.limsrest.LimsRequestReader;
 import org.mskcc.cmo.publisher.pipeline.limsrest.LimsRequestWriter;
+import org.mskcc.cmo.publisher.pipeline.metadb.MetadbServiceReader;
+import org.mskcc.cmo.publisher.pipeline.metadb.MetadbServiceWriter;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecutionListener;
@@ -55,6 +57,7 @@ public class BatchConfiguration {
 
     public static final String LIMS_REQUEST_PUBLISHER_JOB = "limsRequestPublisherJob";
     public static final String METADB_FILE_PUBLISHER_JOB = "metadbFilePublisherJob";
+    public static final String METADB_SERVICE_PUBLISHER_JOB = "metadbServicePublisherJob";
 
     @Value("${chunk.interval:10}")
     private Integer chunkInterval;
@@ -134,6 +137,30 @@ public class BatchConfiguration {
                 .<Map<String, String>, Map<String, String>>chunk(10)
                 .reader(metadbFilePublisherReader())
                 .writer(metadbFilePublisherWriter())
+                .build();
+    }
+
+    /**
+     * metadbServicePublisherJob
+     * @return
+     */
+    @Bean
+    public Job metadbServicePublisherJob() {
+        return jobBuilderFactory.get(METADB_SERVICE_PUBLISHER_JOB)
+                .start(metadbServicePublisherStep())
+                .build();
+    }
+
+    /**
+     * metadbServicePublisherStep
+     * @return
+     */
+    @Bean
+    public Step metadbServicePublisherStep() {
+        return stepBuilderFactory.get("metadbServicePublisherStep")
+                .<String, String>chunk(10)
+                .reader(mdbServiceReader())
+                .writer(mdbServiceWriter())
                 .build();
     }
 
@@ -256,6 +283,18 @@ public class BatchConfiguration {
     @Bean
     public StepExecutionListener limsRequestListener() {
         return new LimsRequestListener();
+    }
+
+    @Bean
+    @StepScope
+    public ItemStreamWriter<String> mdbServiceWriter() {
+        return new MetadbServiceWriter();
+    }
+
+    @Bean
+    @StepScope
+    public ItemStreamReader<String> mdbServiceReader() {
+        return new MetadbServiceReader();
     }
 
     // general spring batch configuration

--- a/src/main/java/org/mskcc/cmo/publisher/pipeline/limsrest/LimsRequestUtil.java
+++ b/src/main/java/org/mskcc/cmo/publisher/pipeline/limsrest/LimsRequestUtil.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;

--- a/src/main/java/org/mskcc/cmo/publisher/pipeline/metadb/MetadbServiceReader.java
+++ b/src/main/java/org/mskcc/cmo/publisher/pipeline/metadb/MetadbServiceReader.java
@@ -1,0 +1,57 @@
+package org.mskcc.cmo.publisher.pipeline.metadb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.ItemStreamException;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+/**
+ *
+ * @author ochoaa
+ */
+public class MetadbServiceReader implements ItemStreamReader<String> {
+    @Value("#{jobParameters[requestIds]}")
+    private String requestIds;
+
+    @Autowired
+    private MetadbServiceUtil metadbServiceUtil;
+
+    private List<String> metadbRequestsList;
+
+    private static final Log LOG = LogFactory.getLog(MetadbServiceReader.class);
+
+    @Override
+    public void open(ExecutionContext ec) throws ItemStreamException {
+        List<String> toReturn = new ArrayList<>();
+        for (String requestId : Arrays.asList(requestIds.split(","))) {
+            try {
+                String requestJson = metadbServiceUtil.getRequestById(requestId);
+                toReturn.add(requestJson);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+        this.metadbRequestsList = toReturn;
+    }
+
+    @Override
+    public void update(ExecutionContext ec) throws ItemStreamException {}
+
+    @Override
+    public void close() throws ItemStreamException {}
+
+    @Override
+    public String read() throws Exception {
+        if (!metadbRequestsList.isEmpty()) {
+            return metadbRequestsList.remove(0);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/mskcc/cmo/publisher/pipeline/metadb/MetadbServiceUtil.java
+++ b/src/main/java/org/mskcc/cmo/publisher/pipeline/metadb/MetadbServiceUtil.java
@@ -1,0 +1,52 @@
+package org.mskcc.cmo.publisher.pipeline.metadb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ *
+ * @author ochoaa
+ */
+@Component
+public class MetadbServiceUtil {
+    private final ObjectMapper mapper = new ObjectMapper();
+    @Value("${metadb.base_url}")
+    private String metadbBaseUrl;
+    @Value("${metadb.request_endpoint}")
+    private String metadbRequestEndpoint;
+
+    /**
+     * Given a requestID, returns response from Metadb web service.
+     * @param requestId
+     * @return String
+     * @throws Exception
+     */
+    public String getRequestById(String requestId) throws Exception {
+        String requestUrl = metadbBaseUrl + metadbRequestEndpoint + requestId;
+        RestTemplate restTemplate = new RestTemplate();
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity();
+        ResponseEntity responseEntity = restTemplate.exchange(requestUrl,
+                HttpMethod.GET, requestEntity, Object.class);
+        String requestJsonString = mapper.writeValueAsString(responseEntity.getBody());
+        return requestJsonString;
+    }
+
+    /**
+     * Returns request entity.
+     * @return HttpEntity
+     */
+    private HttpEntity getRequestEntity() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<Object>(headers);
+    }
+
+}

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -31,3 +31,8 @@ lims.request_deliveries_endpoint=
 
 # metadb publishing failures filepath
 metadb.publishing_failures_filepath=
+
+# metadb service connection properties
+metadb.base_url=
+metadb.request_endpoint=
+metadb.cmo_new_request_topic=


### PR DESCRIPTION
Requests can be fetched directly from Metadb web service and published
to the CMO new requests publishing topic for downstream clients.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>